### PR TITLE
Backporting fix from d6eefa73e77632481c77ed2cd204940d56c1fca0

### DIFF
--- a/alpn-boot/pom.xml
+++ b/alpn-boot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mortbay.jetty.alpn</groupId>
         <artifactId>alpn-project</artifactId>
-        <version>8.1.1.v20141016</version>
+        <version>8.1.1.1-dev</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/alpn-boot/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/alpn-boot/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,6 @@ import java.security.spec.ECParameterSpec;
 
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateParsingException;
-import javax.security.auth.x500.X500Principal;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -95,64 +93,10 @@ final class ClientHandshaker extends Handshaker {
     private final static boolean enableSNIExtension =
             Debug.getBooleanProperty("jsse.enableSNIExtension", true);
 
-    /*
-     * Allow unsafe server certificate change?
-     *
-     * Server certificate change during SSL/TLS renegotiation may be considered
-     * unsafe, as described in the Triple Handshake attacks:
-     *
-     *     https://secure-resumption.com/tlsauth.pdf
-     *
-     * Endpoint identification (See
-     * SSLParameters.getEndpointIdentificationAlgorithm()) is a pretty nice
-     * guarantee that the server certificate change in renegotiation is legal.
-     * However, endpoing identification is only enabled for HTTPS and LDAP
-     * over SSL/TLS by default.  It is not enough to protect SSL/TLS
-     * connections other than HTTPS and LDAP.
-     *
-     * The renegotiation indication extension (See RFC 5764) is a pretty
-     * strong guarantee that the endpoints on both client and server sides
-     * are identical on the same connection.  However, the Triple Handshake
-     * attacks can bypass this guarantee if there is a session-resumption
-     * handshake between the initial full handshake and the renegotiation
-     * full handshake.
-     *
-     * Server certificate change may be unsafe and should be restricted if
-     * endpoint identification is not enabled and the previous handshake is
-     * a session-resumption abbreviated initial handshake, unless the
-     * identities represented by both certificates can be regraded as the
-     * same (See isIdentityEquivalent()).
-     *
-     * Considering the compatibility impact and the actual requirements to
-     * support server certificate change in practice, the system property,
-     * jdk.tls.allowUnsafeServerCertChange, is used to define whether unsafe
-     * server certificate change in renegotiation is allowed or not.  The
-     * default value of the system property is "false".  To mitigate the
-     * compactibility impact, applications may want to set the system
-     * property to "true" at their own risk.
-     *
-     * If the value of the system property is "false", server certificate
-     * change in renegotiation after a session-resumption abbreviated initial
-     * handshake is restricted (See isIdentityEquivalent()).
-     *
-     * If the system property is set to "true" explicitly, the restriction on
-     * server certificate change in renegotiation is disabled.
-     */
-    private final static boolean allowUnsafeServerCertChange =
-        Debug.getBooleanProperty("jdk.tls.allowUnsafeServerCertChange", false);
-
     private List<SNIServerName> requestedServerNames =
             Collections.<SNIServerName>emptyList();
 
     private boolean serverNamesAccepted = false;
-
-    /*
-     * the reserved server certificate chain in previous handshaking
-     *
-     * The server certificate chain is only reserved if the previous
-     * handshake is a session-resumption abbreviated initial handshake.
-     */
-    private X509Certificate[] reservedServerCerts = null;
 
     /*
      * Constructors
@@ -615,18 +559,19 @@ final class ClientHandshaker extends Handshaker {
                 // we wanted to resume, but the server refused
                 session = null;
                 if (!enableNewSession) {
-                    throw new SSLException("New session creation is disabled");
+                    throw new SSLException
+                        ("New session creation is disabled");
                 }
             }
         }
 
         if (resumingSession && session != null) {
             setHandshakeSessionSE(session);
-            // Reserve the handshake state if this is a session-resumption
-            // abbreviated initial handshake.
-            if (isInitialHandshake) {
-                session.setAsSessionResumption(true);
-            }
+
+            // ALPN_CHANGES_BEGIN
+            if (isInitialHandshake)
+                alpnSelected(mesg);
+            // ALPN_CHANGES_END
 
             return;
         }
@@ -660,42 +605,47 @@ final class ClientHandshaker extends Handshaker {
 
         // ALPN_CHANGES_BEGIN
         if (isInitialHandshake)
+            alpnSelected(mesg);
+        // ALPN_CHANGES_END
+    }
+
+    // ALPN_CHANGES_BEGIN
+    private void alpnSelected(ServerHello mesg) throws IOException
+    {
+        ALPN.ClientProvider provider = (ALPN.ClientProvider)(conn != null ? ALPN.get(conn) : ALPN.get(engine));
+        Object ssl = conn != null ? conn : engine;
+        if (provider != null)
         {
-            ALPN.ClientProvider provider = (ALPN.ClientProvider)(conn != null ? ALPN.get(conn) : ALPN.get(engine));
-            Object ssl = conn != null ? conn : engine;
-            if (provider != null)
+            ALPNExtension extension = (ALPNExtension)mesg.extensions.get(ExtensionType.EXT_ALPN);
+            if (extension != null)
             {
-                ALPNExtension extension = (ALPNExtension)mesg.extensions.get(ExtensionType.EXT_ALPN);
-                if (extension != null)
+                List<String> protocols = extension.getProtocols();
+                try
                 {
-                    List<String> protocols = extension.getProtocols();
-                    try
-                    {
-                        String protocol = protocols == null || protocols.isEmpty() ? null : protocols.get(0);
-                        if (ALPN.debug)
-                            System.err.println("[C] ALPN protocol '" + protocol + "' selected by server for " + ssl);
-                        provider.selected(protocol);
-                    }
-                    catch (Throwable x)
-                    {
-                        fatalSE(Alerts.alert_no_application_protocol, "Could not negotiate application protocol", x);
-                    }
-                }
-                else
-                {
+                    String protocol = protocols == null || protocols.isEmpty() ? null : protocols.get(0);
                     if (ALPN.debug)
-                        System.err.println("[C] ALPN not supported by server for " + ssl);
-                    provider.unsupported();
+                        System.err.println("[C] ALPN protocol '" + protocol + "' selected by server for " + ssl);
+                    provider.selected(protocol);
+                }
+                catch (Throwable x)
+                {
+                    fatalSE(Alerts.alert_no_application_protocol, "Could not negotiate application protocol", x);
                 }
             }
             else
             {
                 if (ALPN.debug)
-                    System.err.println("[C] ALPN client provider not present for " + ssl);
+                    System.err.println("[C] ALPN not supported by server for " + ssl);
+                provider.unsupported();
             }
         }
-        // ALPN_CHANGES_END
+        else
+        {
+            if (ALPN.debug)
+                System.err.println("[C] ALPN client provider not present for " + ssl);
+        }
     }
+    // ALPN_CHANGES_END
 
     /*
      * Server's own key was either a signing-only key, or was too
@@ -1170,13 +1120,6 @@ final class ClientHandshaker extends Handshaker {
         }
 
         /*
-         * Reset the handshake state if this is not an initial handshake.
-         */
-        if (!isInitialHandshake) {
-            session.setAsSessionResumption(false);
-        }
-
-        /*
          * OK, it verified.  If we're doing the fast handshake, add that
          * "Finished" message to the hash of handshake messages, then send
          * our own change_cipher_spec and Finished message for the server
@@ -1274,23 +1217,8 @@ final class ClientHandshaker extends Handshaker {
                 System.out.println("%% No cached client session");
             }
         }
-        if (session != null) {
-            // If unsafe server certificate change is not allowed, reserve
-            // current server certificates if the previous handshake is a
-            // session-resumption abbreviated initial handshake.
-            if (!allowUnsafeServerCertChange && session.isSessionResumption()) {
-                try {
-                    // If existing, peer certificate chain cannot be null.
-                    reservedServerCerts =
-                        (X509Certificate[])session.getPeerCertificates();
-                } catch (SSLPeerUnverifiedException puve) {
-                    // Maybe not certificate-based, ignore the exception.
-                }
-            }
-
-            if (!session.isRejoinable()) {
-                session = null;
-            }
+        if ((session != null) && (session.isRejoinable() == false)) {
+            session = null;
         }
 
         if (session != null) {
@@ -1487,26 +1415,8 @@ final class ClientHandshaker extends Handshaker {
         }
         X509Certificate[] peerCerts = mesg.getCertificateChain();
         if (peerCerts.length == 0) {
-            fatalSE(Alerts.alert_bad_certificate, "empty certificate chain");
-        }
-
-        // Allow server certificate change in client side during renegotiation
-        // after a session-resumption abbreviated initial handshake?
-        //
-        // DO NOT need to check allowUnsafeServerCertChange here. We only
-        // reserve server certificates when allowUnsafeServerCertChange is
-        // flase.
-        if (reservedServerCerts != null) {
-            // It is not necessary to check the certificate update if endpoint
-            // identification is enabled.
-            String identityAlg = getEndpointIdentificationAlgorithmSE();
-            if ((identityAlg == null || identityAlg.length() == 0) &&
-                !isIdentityEquivalent(peerCerts[0], reservedServerCerts[0])) {
-
-                fatalSE(Alerts.alert_bad_certificate,
-                        "server certificate change is restricted " +
-                        "during renegotiation");
-            }
+            fatalSE(Alerts.alert_bad_certificate,
+                "empty certificate chain");
         }
 
         // ask the trust manager to verify the chain
@@ -1544,82 +1454,5 @@ final class ClientHandshaker extends Handshaker {
             fatalSE(Alerts.alert_certificate_unknown, e);
         }
         session.setPeerCertificates(peerCerts);
-    }
-
-    /*
-     * Whether the certificates can represent the same identity?
-     *
-     * The certificates can be used to represent the same identity:
-     *     1. If the subject alternative names of IP address are present in
-     *        both certificates, they should be identical; otherwise,
-     *     2. if the subject alternative names of DNS name are present in
-     *        both certificates, they should be identical; otherwise,
-     *     3. if the subject fields are present in both certificates, the
-     *        certificate subjects and issuers should be identical.
-     */
-    private static boolean isIdentityEquivalent(X509Certificate thisCert,
-            X509Certificate prevCert) {
-        if (thisCert.equals(prevCert)) {
-            return true;
-        }
-
-        // check the iPAddress field in subjectAltName extension
-        Object thisIPAddress = getSubjectAltName(thisCert, 7);  // 7: iPAddress
-        Object prevIPAddress = getSubjectAltName(prevCert, 7);
-        if (thisIPAddress != null && prevIPAddress!= null) {
-            // only allow the exactly match
-            return Objects.equals(thisIPAddress, prevIPAddress);
-        }
-
-        // check the dNSName field in subjectAltName extension
-        Object thisDNSName = getSubjectAltName(thisCert, 2);    // 2: dNSName
-        Object prevDNSName = getSubjectAltName(prevCert, 2);
-        if (thisDNSName != null && prevDNSName!= null) {
-            // only allow the exactly match
-            return Objects.equals(thisDNSName, prevDNSName);
-        }
-
-        // check the certificate subject and issuer
-        X500Principal thisSubject = thisCert.getSubjectX500Principal();
-        X500Principal prevSubject = prevCert.getSubjectX500Principal();
-        X500Principal thisIssuer = thisCert.getIssuerX500Principal();
-        X500Principal prevIssuer = prevCert.getIssuerX500Principal();
-        if (!thisSubject.getName().isEmpty() &&
-                !prevSubject.getName().isEmpty() &&
-                thisSubject.equals(prevSubject) &&
-                thisIssuer.equals(prevIssuer)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /*
-     * Returns the subject alternative name of the specified type in the
-     * subjectAltNames extension of a certificate.
-     */
-    private static Object getSubjectAltName(X509Certificate cert, int type) {
-        Collection<List<?>> subjectAltNames;
-
-        try {
-            subjectAltNames = cert.getSubjectAlternativeNames();
-        } catch (CertificateParsingException cpe) {
-            if (debug != null && Debug.isOn("handshake")) {
-                System.out.println(
-                        "Attempt to obtain subjectAltNames extension failed!");
-            }
-            return null;
-        }
-
-        if (subjectAltNames != null) {
-            for (List<?> subjectAltName : subjectAltNames) {
-                int subjectAltNameType = (Integer)subjectAltName.get(0);
-                if (subjectAltNameType == type) {
-                    return subjectAltName.get(1);
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/alpn-tests/pom.xml
+++ b/alpn-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mortbay.jetty.alpn</groupId>
         <artifactId>alpn-project</artifactId>
-        <version>8.1.1.v20141016</version>
+        <version>8.1.1.1-dev</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/alpn-tests/src/test/java/org/mortbay/jetty/alpn/AbstractALPNTest.java
+++ b/alpn-tests/src/test/java/org/mortbay/jetty/alpn/AbstractALPNTest.java
@@ -1,0 +1,362 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2014 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.mortbay.jetty.alpn;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+
+import org.eclipse.jetty.alpn.ALPN;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractALPNTest<T>
+{
+    protected abstract SSLResult<T> performTLSHandshake(SSLResult<T> handshake, ALPN.ClientProvider clientProvider, ALPN.ServerProvider serverProvider) throws Exception;
+
+    protected abstract void performTLSClose(SSLResult<T> sslResult) throws Exception;
+
+    protected abstract void performDataExchange(SSLResult<T> sslResult) throws Exception;
+
+    protected abstract void performTLSRenegotiation(SSLResult<T> sslResult, boolean client) throws Exception;
+
+    protected abstract SSLSession getSSLSession(SSLResult<T> sslResult, boolean client) throws Exception;
+
+    @Before
+    public void prepare() throws Exception
+    {
+        Assert.assertNull("ALPN classes must be in the bootclasspath.", ALPN.class.getClassLoader());
+        ALPN.debug = true;
+    }
+
+    @Test
+    public void testALPNSuccessful() throws Exception
+    {
+        final String protocolName = "test";
+        final CountDownLatch latch = new CountDownLatch(3);
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.assertEquals(protocolName, protocol);
+                latch.countDown();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.countDown();
+                return protocol;
+            }
+        };
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        // Verify that we can exchange data without errors.
+        performDataExchange(sslResult);
+
+        performTLSClose(sslResult);
+    }
+
+    @Test
+    public void testServerDoesNotSendALPN() throws Exception
+    {
+        final String protocolName = "test";
+        final CountDownLatch latch = new CountDownLatch(3);
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                latch.countDown();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.fail();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.countDown();
+                // By returning null, the server won't send the ALPN extension.
+                return null;
+            }
+        };
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        // Verify that we can exchange data without errors.
+        performDataExchange(sslResult);
+
+        performTLSClose(sslResult);
+    }
+
+    @Test
+    public void testServerThrowsException() throws Exception
+    {
+        final String protocolName = "test";
+        final CountDownLatch latch = new CountDownLatch(3);
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                latch.countDown();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.fail();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                // By throwing, the server will close the connection.
+                throw new IllegalStateException("explicitly_thrown_by_test");
+            }
+        };
+
+        try
+        {
+            performTLSHandshake(null, clientProvider, serverProvider);
+            Assert.fail();
+        }
+        catch (Exception x)
+        {
+            // Expected.
+        }
+    }
+    
+    @Test
+    public void testClientTLSRenegotiation() throws Exception
+    {
+        testTLSRenegotiation(true);
+    }
+
+    @Test
+    public void testServerTLSRenegotiation() throws Exception
+    {
+        testTLSRenegotiation(false);
+    }
+
+    private void testTLSRenegotiation(boolean client) throws Exception
+    {
+        final String protocolName = "test";
+        final AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(3));
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.get().countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                latch.get().countDown();
+                Assert.fail();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                latch.get().countDown();
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+                return protocol;
+            }
+        };
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
+
+        // Verify that we can exchange data without errors.
+        performDataExchange(sslResult);
+
+        latch.set(new CountDownLatch(1));
+        performTLSRenegotiation(sslResult, client);
+
+        // The data exchange may trigger the completion of the TLS renegotiation.
+        performDataExchange(sslResult);
+
+        // ALPN must not trigger.
+        Assert.assertFalse(latch.get().await(1, TimeUnit.SECONDS));
+
+        performTLSClose(sslResult);
+    }
+
+    @Test
+    public void testTLSSessionResumption() throws Exception
+    {
+        final String protocolName = "test";
+        final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.get().countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+                return protocol;
+            }
+        };
+
+        // First TLS handshake.
+        latch.set(new CountDownLatch(3));
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
+        SSLSession clientSession1 = getSSLSession(sslResult, true);
+        SSLSession serverSession1 = getSSLSession(sslResult, false);
+        // Must close the first session before starting the second one.
+        performTLSClose(sslResult);
+
+        // Second TLS handshake.
+        latch.set(new CountDownLatch(3));
+        sslResult = performTLSHandshake(sslResult, clientProvider, serverProvider);
+        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
+
+        Assert.assertSame(clientSession1, getSSLSession(sslResult, true));
+        Assert.assertSame(serverSession1, getSSLSession(sslResult, false));
+
+        performTLSClose(sslResult);
+    }
+
+    public static class SSLResult<S>
+    {
+        public SSLContext context;
+        public S client;
+        public S server;
+    }
+}

--- a/alpn-tests/src/test/java/org/mortbay/jetty/alpn/SSLSocketALPNTest.java
+++ b/alpn-tests/src/test/java/org/mortbay/jetty/alpn/SSLSocketALPNTest.java
@@ -18,38 +18,45 @@
 
 package org.mortbay.jetty.alpn;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
 import org.eclipse.jetty.alpn.ALPN;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.Test;
 
-public class SSLSocketALPNTest
+public class SSLSocketALPNTest extends AbstractALPNTest<SSLSocket>
 {
-    @Test
-    public void testNegotiationSuccessful() throws Exception
+    private SSLServerSocket acceptor;
+
+    @After
+    public void dispose() throws Exception
     {
-        ALPN.debug = true;
+        if (acceptor != null)
+            acceptor.close();
+    }
 
-        SSLContext context = SSLSupport.newSSLContext();
+    @Override
+    protected SSLResult<SSLSocket> performTLSHandshake(SSLResult<SSLSocket> handshake, ALPN.ClientProvider clientProvider, final ALPN.ServerProvider serverProvider) throws Exception
+    {
+        SSLContext sslContext = handshake == null ? SSLSupport.newSSLContext() : handshake.context;
 
-        final int readTimeout = 50000;
-        final String data = "data";
-        final String protocolName = "test";
-        final AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(3));
-        final SSLServerSocket server = (SSLServerSocket)context.getServerSocketFactory().createServerSocket();
-        server.bind(new InetSocketAddress("localhost", 0));
-        final CountDownLatch handshakeLatch = new CountDownLatch(2);
+        final CountDownLatch latch = new CountDownLatch(2);
+        final SSLResult<SSLSocket> sslResult = new SSLResult<>();
+        sslResult.context = sslContext;
+        final int readTimeout = 5000;
+        if (handshake == null)
+        {
+            acceptor = (SSLServerSocket)sslContext.getServerSocketFactory().createServerSocket();
+            acceptor.bind(new InetSocketAddress("localhost", 0));
+        }
+
         new Thread()
         {
             @Override
@@ -57,66 +64,15 @@ public class SSLSocketALPNTest
             {
                 try
                 {
-                    final SSLSocket socket = (SSLSocket)server.accept();
-                    socket.setUseClientMode(false);
-                    socket.setSoTimeout(readTimeout);
-                    ALPN.put(socket, new ALPN.ServerProvider()
-                    {
-                        @Override
-                        public void unsupported()
-                        {
-                            ALPN.remove(socket);
-                        }
+                    SSLSocket serverSSLSocket = (SSLSocket)acceptor.accept();
+                    System.err.println(serverSSLSocket);
+                    sslResult.server = serverSSLSocket;
 
-                        @Override
-                        public String select(List<String> protocols)
-                        {
-                            ALPN.remove(socket);
-                            Assert.assertEquals(1, protocols.size());
-                            String protocol = protocols.get(0);
-                            Assert.assertEquals(protocolName, protocol);
-                            latch.get().countDown();
-                            return protocol;
-                        }
-                    });
-                    socket.addHandshakeCompletedListener(event -> handshakeLatch.countDown());
-                    socket.startHandshake();
-
-                    InputStream serverInput = socket.getInputStream();
-                    for (int i = 0; i < data.length(); ++i)
-                    {
-                        int read = serverInput.read();
-                        Assert.assertEquals(data.charAt(i), read);
-                    }
-
-                    OutputStream serverOutput = socket.getOutputStream();
-                    serverOutput.write(data.getBytes("UTF-8"));
-                    serverOutput.flush();
-
-                    for (int i = 0; i < data.length(); ++i)
-                    {
-                        int read = serverInput.read();
-                        Assert.assertEquals(data.charAt(i), read);
-                    }
-
-                    serverOutput.write(data.getBytes("UTF-8"));
-                    serverOutput.flush();
-
-                    // Re-handshake
-                    socket.startHandshake();
-
-                    for (int i = 0; i < data.length(); ++i)
-                    {
-                        int read = serverInput.read();
-                        Assert.assertEquals(data.charAt(i), read);
-                    }
-
-                    serverOutput.write(data.getBytes("UTF-8"));
-                    serverOutput.flush();
-
-                    Assert.assertEquals(4, latch.get().getCount());
-
-                    socket.close();
+                    serverSSLSocket.setUseClientMode(false);
+                    serverSSLSocket.setSoTimeout(readTimeout);
+                    ALPN.put(serverSSLSocket, serverProvider);
+                    serverSSLSocket.startHandshake();
+                    latch.countDown();
                 }
                 catch (Exception x)
                 {
@@ -125,79 +81,66 @@ public class SSLSocketALPNTest
             }
         }.start();
 
-        final SSLSocket client = (SSLSocket)context.getSocketFactory().createSocket("localhost", server.getLocalPort());
-        client.setUseClientMode(true);
-        client.setSoTimeout(readTimeout);
-        ALPN.put(client, new ALPN.ClientProvider()
-        {
-            @Override
-            public List<String> protocols()
-            {
-                latch.get().countDown();
-                return Arrays.asList(protocolName);
-            }
+        SSLSocket clientSSLSocket = (SSLSocket)sslContext.getSocketFactory().createSocket("localhost", acceptor.getLocalPort());
+        sslResult.client = clientSSLSocket;
+        latch.countDown();
 
-            @Override
-            public void unsupported()
-            {
-                ALPN.remove(client);
-            }
+        clientSSLSocket.setUseClientMode(true);
+        clientSSLSocket.setSoTimeout(readTimeout);
+        ALPN.put(clientSSLSocket, clientProvider);
+        clientSSLSocket.startHandshake();
 
-            @Override
-            public void selected(String protocol)
-            {
-                ALPN.remove(client);
-                Assert.assertEquals(protocolName, protocol);
-                latch.get().countDown();
-            }
-        });
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+        return sslResult;
+    }
 
-        client.addHandshakeCompletedListener(event -> handshakeLatch.countDown());
-        client.startHandshake();
+    @Override
+    protected void performTLSClose(SSLResult<SSLSocket> sslResult) throws Exception
+    {
+        sslResult.client.close();
+        sslResult.server.close();
+    }
 
-        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
-        Assert.assertTrue(handshakeLatch.await(5, TimeUnit.SECONDS));
+    @Override
+    protected void performDataExchange(SSLResult<SSLSocket> sslResult) throws Exception
+    {
+        SSLSocket clientSSLSocket = sslResult.client;
+        SSLSocket serverSSLSocket = sslResult.server;
 
-        // Check whether we can write real data to the connection
-        OutputStream clientOutput = client.getOutputStream();
-        clientOutput.write(data.getBytes("UTF-8"));
-        clientOutput.flush();
+        byte[] data = new byte[1024];
+        new Random().nextBytes(data);
 
-        InputStream clientInput = client.getInputStream();
-        for (int i = 0; i < data.length(); ++i)
-        {
-            int read = clientInput.read();
-            Assert.assertEquals(data.charAt(i), read);
-        }
+        // Write the data.
+        clientSSLSocket.getOutputStream().write(data);
 
-        // Re-handshake
-        latch.set(new CountDownLatch(4));
-        client.startHandshake();
-        Assert.assertEquals(4, latch.get().getCount());
+        // Read the data.
+        byte[] buffer = new byte[data.length];
+        int read = 0;
+        while (read < data.length)
+            read += serverSSLSocket.getInputStream().read(buffer);
 
-        clientOutput.write(data.getBytes("UTF-8"));
-        clientOutput.flush();
+        // Write the data back.
+        serverSSLSocket.getOutputStream().write(buffer, 0, read);
 
-        for (int i = 0; i < data.length(); ++i)
-        {
-            int read = clientInput.read();
-            Assert.assertEquals(data.charAt(i), read);
-        }
+        // Read the echo.
+        read = 0;
+        while (read < data.length)
+            read += clientSSLSocket.getInputStream().read(buffer);
+    }
 
-        clientOutput.write(data.getBytes("UTF-8"));
-        clientOutput.flush();
+    @Override
+    protected void performTLSRenegotiation(SSLResult<SSLSocket> sslResult, boolean client) throws Exception
+    {
+        if (client)
+            sslResult.client.startHandshake();
+        else
+            sslResult.server.startHandshake();
+    }
 
-        for (int i = 0; i < data.length(); ++i)
-        {
-            int read = clientInput.read();
-            Assert.assertEquals(data.charAt(i), read);
-        }
-
-        int read = clientInput.read();
-        Assert.assertEquals(-1, read);
-
-        client.close();
-
-        server.close();
+    @Override
+    protected SSLSession getSSLSession(SSLResult<SSLSocket> sslResult, boolean client) throws Exception
+    {
+        SSLSocket sslSocket = client ? sslResult.client : sslResult.server;
+        return sslSocket.getSession();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mortbay.jetty.alpn</groupId>
     <artifactId>alpn-project</artifactId>
-    <version>8.1.1.v20141016</version>
+    <version>8.1.1.1-dev</version>
     <packaging>pom</packaging>
     <name>Jetty :: ALPN :: Project</name>
 
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/jetty-project/jetty-alpn.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jetty-project/jetty-alpn.git</developerConnection>
         <url>https://github.com/jetty-project/jetty-alpn</url>
-      <tag>alpn-project-8.1.1.v20141016</tag>
+      <tag>alpn-project-8.1.1.1-dev</tag>
   </scm>
 
     <modules>


### PR DESCRIPTION
Issue https://github.com/jetty-project/jetty-alpn/issues/5 was fixed only for the latest code.  alpn-boot versions are tightly coupled to JDK versions, and so anyone not using the latest JDK version will not get the benefits of the fix.  It would be nice to maintain a branch pre jdk8_u25-b17 specifically for alpn-boot issues to account for this scenario.
