### PR TITLE
Backport 478e4284efac50cf5a811aac3728b210fc929a5c

### DIFF
--- a/alpn-boot/pom.xml
+++ b/alpn-boot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mortbay.jetty.alpn</groupId>
         <artifactId>alpn-project</artifactId>
-        <version>7.1.0.v20141016</version>
+        <version>7.0.0.1-dev</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/alpn-boot/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/alpn-boot/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -567,6 +567,12 @@ final class ClientHandshaker extends Handshaker {
             }
 
             setHandshakeSessionSE(session);
+
+            // ALPN_CHANGES_BEGIN
+            if (isInitialHandshake)
+                alpnSelected(mesg);
+            // ALPN_CHANGES_END
+
             return;
         }
 
@@ -596,42 +602,47 @@ final class ClientHandshaker extends Handshaker {
 
         // ALPN_CHANGES_BEGIN
         if (isInitialHandshake)
+            alpnSelected(mesg);
+        // ALPN_CHANGES_END
+    }
+
+    // ALPN_CHANGES_BEGIN
+    private void alpnSelected(ServerHello mesg) throws IOException
+    {
+        ALPN.ClientProvider provider = (ALPN.ClientProvider)(conn != null ? ALPN.get(conn) : ALPN.get(engine));
+        Object ssl = conn != null ? conn : engine;
+        if (provider != null)
         {
-            ALPN.ClientProvider provider = (ALPN.ClientProvider)(conn != null ? ALPN.get(conn) : ALPN.get(engine));
-            Object ssl = conn != null ? conn : engine;
-            if (provider != null)
+            ALPNExtension extension = (ALPNExtension)mesg.extensions.get(ExtensionType.EXT_ALPN);
+            if (extension != null)
             {
-                ALPNExtension extension = (ALPNExtension)mesg.extensions.get(ExtensionType.EXT_ALPN);
-                if (extension != null)
+                List<String> protocols = extension.getProtocols();
+                try
                 {
-                    List<String> protocols = extension.getProtocols();
-                    try
-                    {
-                        String protocol = protocols == null || protocols.isEmpty() ? null : protocols.get(0);
-                        if (ALPN.debug)
-                            System.err.println("[C] ALPN protocol '" + protocol + "' selected by server for " + ssl);
-                        provider.selected(protocol);
-                    }
-                    catch (Throwable x)
-                    {
-                        fatalSE(Alerts.alert_no_application_protocol, "Could not negotiate application protocol", x);
-                    }
-                }
-                else
-                {
+                    String protocol = protocols == null || protocols.isEmpty() ? null : protocols.get(0);
                     if (ALPN.debug)
-                        System.err.println("[C] ALPN not supported by server for " + ssl);
-                    provider.unsupported();
+                        System.err.println("[C] ALPN protocol '" + protocol + "' selected by server for " + ssl);
+                    provider.selected(protocol);
+                }
+                catch (Throwable x)
+                {
+                    fatalSE(Alerts.alert_no_application_protocol, "Could not negotiate application protocol", x);
                 }
             }
             else
             {
                 if (ALPN.debug)
-                    System.err.println("[C] ALPN client provider not present for " + ssl);
+                    System.err.println("[C] ALPN not supported by server for " + ssl);
+                provider.unsupported();
             }
         }
-        // ALPN_CHANGES_END
+        else
+        {
+            if (ALPN.debug)
+                System.err.println("[C] ALPN client provider not present for " + ssl);
+        }
     }
+    // ALPN_CHANGES_END
 
     /*
      * Server's own key was either a signing-only key, or was too

--- a/alpn-tests/pom.xml
+++ b/alpn-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mortbay.jetty.alpn</groupId>
         <artifactId>alpn-project</artifactId>
-        <version>7.1.0.v20141016</version>
+        <version>7.0.0.1-dev</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/alpn-tests/src/test/java/org/mortbay/jetty/alpn/AbstractALPNTest.java
+++ b/alpn-tests/src/test/java/org/mortbay/jetty/alpn/AbstractALPNTest.java
@@ -1,0 +1,362 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2014 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.mortbay.jetty.alpn;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+
+import org.eclipse.jetty.alpn.ALPN;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractALPNTest<T>
+{
+    protected abstract SSLResult<T> performTLSHandshake(SSLResult<T> handshake, ALPN.ClientProvider clientProvider, ALPN.ServerProvider serverProvider) throws Exception;
+
+    protected abstract void performTLSClose(SSLResult<T> sslResult) throws Exception;
+
+    protected abstract void performDataExchange(SSLResult<T> sslResult) throws Exception;
+
+    protected abstract void performTLSRenegotiation(SSLResult<T> sslResult, boolean client) throws Exception;
+
+    protected abstract SSLSession getSSLSession(SSLResult<T> sslResult, boolean client) throws Exception;
+
+    @Before
+    public void prepare() throws Exception
+    {
+        Assert.assertNull("ALPN classes must be in the bootclasspath.", ALPN.class.getClassLoader());
+        ALPN.debug = true;
+    }
+
+    @Test
+    public void testALPNSuccessful() throws Exception
+    {
+        final String protocolName = "test";
+        final CountDownLatch latch = new CountDownLatch(3);
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.assertEquals(protocolName, protocol);
+                latch.countDown();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.countDown();
+                return protocol;
+            }
+        };
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        // Verify that we can exchange data without errors.
+        performDataExchange(sslResult);
+
+        performTLSClose(sslResult);
+    }
+
+    @Test
+    public void testServerDoesNotSendALPN() throws Exception
+    {
+        final String protocolName = "test";
+        final CountDownLatch latch = new CountDownLatch(3);
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                latch.countDown();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.fail();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.countDown();
+                // By returning null, the server won't send the ALPN extension.
+                return null;
+            }
+        };
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        // Verify that we can exchange data without errors.
+        performDataExchange(sslResult);
+
+        performTLSClose(sslResult);
+    }
+
+    @Test
+    public void testServerThrowsException() throws Exception
+    {
+        final String protocolName = "test";
+        final CountDownLatch latch = new CountDownLatch(3);
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                latch.countDown();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.fail();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                // By throwing, the server will close the connection.
+                throw new IllegalStateException("explicitly_thrown_by_test");
+            }
+        };
+
+        try
+        {
+            performTLSHandshake(null, clientProvider, serverProvider);
+            Assert.fail();
+        }
+        catch (Exception x)
+        {
+            // Expected.
+        }
+    }
+    
+    @Test
+    public void testClientTLSRenegotiation() throws Exception
+    {
+        testTLSRenegotiation(true);
+    }
+
+    @Test
+    public void testServerTLSRenegotiation() throws Exception
+    {
+        testTLSRenegotiation(false);
+    }
+
+    private void testTLSRenegotiation(boolean client) throws Exception
+    {
+        final String protocolName = "test";
+        final AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(3));
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.get().countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                latch.get().countDown();
+                Assert.fail();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                latch.get().countDown();
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+                return protocol;
+            }
+        };
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
+
+        // Verify that we can exchange data without errors.
+        performDataExchange(sslResult);
+
+        latch.set(new CountDownLatch(1));
+        performTLSRenegotiation(sslResult, client);
+
+        // The data exchange may trigger the completion of the TLS renegotiation.
+        performDataExchange(sslResult);
+
+        // ALPN must not trigger.
+        Assert.assertFalse(latch.get().await(1, TimeUnit.SECONDS));
+
+        performTLSClose(sslResult);
+    }
+
+    @Test
+    public void testTLSSessionResumption() throws Exception
+    {
+        final String protocolName = "test";
+        final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+        ALPN.ClientProvider clientProvider = new ALPN.ClientProvider()
+        {
+            @Override
+            public List<String> protocols()
+            {
+                latch.get().countDown();
+                return Arrays.asList(protocolName);
+            }
+
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public void selected(String protocol)
+            {
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+            }
+        };
+        ALPN.ServerProvider serverProvider = new ALPN.ServerProvider()
+        {
+            @Override
+            public void unsupported()
+            {
+                Assert.fail();
+            }
+
+            @Override
+            public String select(List<String> protocols)
+            {
+                Assert.assertEquals(1, protocols.size());
+                String protocol = protocols.get(0);
+                Assert.assertEquals(protocolName, protocol);
+                latch.get().countDown();
+                return protocol;
+            }
+        };
+
+        // First TLS handshake.
+        latch.set(new CountDownLatch(3));
+        SSLResult<T> sslResult = performTLSHandshake(null, clientProvider, serverProvider);
+        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
+        SSLSession clientSession1 = getSSLSession(sslResult, true);
+        SSLSession serverSession1 = getSSLSession(sslResult, false);
+        // Must close the first session before starting the second one.
+        performTLSClose(sslResult);
+
+        // Second TLS handshake.
+        latch.set(new CountDownLatch(3));
+        sslResult = performTLSHandshake(sslResult, clientProvider, serverProvider);
+        Assert.assertTrue(latch.get().await(5, TimeUnit.SECONDS));
+
+        Assert.assertSame(clientSession1, getSSLSession(sslResult, true));
+        Assert.assertSame(serverSession1, getSSLSession(sslResult, false));
+
+        performTLSClose(sslResult);
+    }
+
+    public static class SSLResult<S>
+    {
+        public SSLContext context;
+        public S client;
+        public S server;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mortbay.jetty.alpn</groupId>
     <artifactId>alpn-project</artifactId>
-    <version>7.1.0.v20141016</version>
+    <version>7.0.0.1-dev</version>
     <packaging>pom</packaging>
     <name>Jetty :: ALPN :: Project</name>
 


### PR DESCRIPTION
Issue #5 was fixed only for the latest code. alpn-boot versions are tightly coupled to JDK versions, and so anyone not using the latest JDK version will not get the benefits of the fix. It would be nice to maintain a branch pre jdk7_u71-b14 specifically for alpn-boot issues to account for this scenario.
